### PR TITLE
Add support for encoding ACTION payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .idea
+.vscode


### PR DESCRIPTION
This change adds a new encode API `bej_action_encoder()` which will facilitate encoding of payloads for requests against one of the defined Actions for a given resource by determining the appropriate dictionary offset and child count for the given Action's dictionary subset prior to the first call of `bej_encode_stream()`.