### PR TITLE
generate_dictionaries.py pointed to v1_0_0 of annotations schema

### DIFF
--- a/generate_dictionaries.py
+++ b/generate_dictionaries.py
@@ -149,7 +149,7 @@ if __name__ == '__main__':
         annotation_dictionary = dictionary.generate_annotation_schema_dictionary(
             schema_dir_csdl,
             schema_dir_json,
-            'v1_0_0'
+            'v1'
         )
 
         if annotation_dictionary and annotation_dictionary.dictionary \


### PR DESCRIPTION
The step in generate_dicionaries.py to build the binary and map files for the annotations schema dictionary was pointing to a hard-coded schema version of v1_0_0, preventing any new annotations added later on from being included in the dictionary binary. This script now will attempt to build the dictionary binary using
redfish-payload-annotations-v1.json, which is a clone of the latest version of the annotation schema.

Also fixed a bug when building a list of annotation schema JSON files with version less than a given version string could result in inconsistent ordering of list members, potentially resulting in nondeterministic sequence numbers being assigned to annotations.

Also fixed a bug where the version32 form of schema version strings was erroneously being used to compare versions. This would result in cases such as 'v1_2_0` (0xF1F2F000) being determined to be newer than 'v1_12_0' (0xF112F000).