### PR TITLE
Removed Python version requirement; the tool should work on all versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: jammy
 language: python
 python:
-   - "3.6"
    - "3.8"
    - "3.9"
-   - "3.10-dev"
+   - "3.10"
+   - "3.11"
 
 env:
    - PIPENV_IGNORE_VIRTUALENVS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: jammy
 language: python
 python:
    - "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,3 @@ lxml = "*"
 tabulate = "*"
 GitPython = "*"
 requests = "*"
-
-[requires]
-python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -165,7 +165,6 @@
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
                 "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.11"
         }
     },


### PR DESCRIPTION
Travis started failing recently for tests using newer versions of Python. It stops on the step asking to install Python3.6, and times out since it's waiting for a user to press "Y".