### PR TITLE
Add support for additional deferred binding string expansions during …

### DIFF
--- a/rdebej/decode.py
+++ b/rdebej/decode.py
@@ -339,7 +339,7 @@ def bej_decode_stream(output_stream, input_stream, schema_dict, annot_dict, entr
                 bej_decode_name(annot_dict, seq, selector, flags,  entries_by_seq, entries_by_seq_selector, output_stream)
 
             if is_deferred_binding:
-                bindings_to_resolve = re.findall('(%M|%[LTPI][0-9]+)\.?[0-9]*.*?', value)
+                bindings_to_resolve = re.findall('(%[BCMSU]|%[LTPI][0-9]+)\.?[0-9]*.*?', value)
                 for binding in bindings_to_resolve:
                     if binding in deferred_binding_strings:
                         value = value.replace(binding, deferred_binding_strings[binding])


### PR DESCRIPTION
…decode

Updated bej_decode_stream() to perform deferred binding string expansion for the following bindings listed in Table 42 of DSP0218 v1.1.2:

+ %B - MC-assigned URI for a Battery resource managed by the MC.
+ %C - MC-assigned link to the Chassis resource within which an RDE device resides.
+ %S - MC-assigned link to the ComputerSystem resource within which an RDE device resides.
+ %U - UEFI device path assigned to an RDE device by the MC and/or BIOS.