### PR TITLE
Remove default AutoExpand behavior from action parameters

### DIFF
--- a/rdebej/dictionary.py
+++ b/rdebej/dictionary.py
@@ -36,6 +36,7 @@ ODATA_TYPE_DEFINITION = '{http://docs.oasis-open.org/odata/ns/edm}TypeDefinition
 ODATA_ENTITY_TYPE = '{http://docs.oasis-open.org/odata/ns/edm}EntityType'
 ODATA_NAVIGATION_PROPERTY = '{http://docs.oasis-open.org/odata/ns/edm}NavigationProperty'
 ODATA_ACTION_TYPE = '{http://docs.oasis-open.org/odata/ns/edm}Action'
+ODATA_PARAMETER_TYPE = '{http://docs.oasis-open.org/odata/ns/edm}Parameter'
 ODATA_TERM_TYPE = '{http://docs.oasis-open.org/odata/ns/edm}Term'
 ODATA_ALL_NAMESPACES = {'edm': 'http://docs.oasis-open.org/odata/ns/edm', 'edmx': 'http://docs.oasis-open.org/odata/ns/edmx'}
 
@@ -274,7 +275,8 @@ def get_properties(some_type, path=PROPERTY_PATH, can_sort_by_version=False):
 
         property_flags = property_is_nullable_flag + ',' + property_permissions
 
-        is_auto_expand = property_element.tag != ODATA_NAVIGATION_PROPERTY \
+        is_auto_expand = (property_element.tag != ODATA_NAVIGATION_PROPERTY \
+                          and property_element.tag != ODATA_PARAMETER_TYPE) \
             or (property_element.tag == ODATA_NAVIGATION_PROPERTY
                 and len(property_element.xpath('child::edm:Annotation[@Term=\'OData.AutoExpand\']',
                                                namespaces=ODATA_ALL_NAMESPACES)))


### PR DESCRIPTION
Several resource actions have parameters which accept a resource collection value. Currently the rde_schema_dictionary_gen.py script interprets these parameters as being AutoExpand by default, causing the schema dictionary to have the full schema dictionary of the collection parameter's member type to be embedded within it. This change removes that default behavior for action parameters based on the assumption that Redfish clients will generally be passing a list of @odata.id references in these action requests instead of full representations of the collection members.